### PR TITLE
tests gte and lte lookups for DateField

### DIFF
--- a/ldapdb/tests.py
+++ b/ldapdb/tests.py
@@ -150,6 +150,14 @@ class WhereTestCase(TestCase):
         where.add(self._build_lookup("birthday", 'exact', '2013-09-03', field=DateField), AND)
         self.assertEqual(self._where_as_ldap(where), "(birthday=2013-09-03)")
 
+        where = WhereNode()
+        where.add(self._build_lookup("birthday", 'gte', '2013-09-03', field=DateField), AND)
+        self.assertEqual(self._where_as_ldap(where), "(birthday>=2013-09-03)")
+
+        where = WhereNode()
+        where.add(self._build_lookup("birthday", 'lte', '2013-09-03', field=DateField), AND)
+        self.assertEqual(self._where_as_ldap(where), "(birthday<=2013-09-03)")
+
     def test_and(self):
         where = WhereNode()
         where.add(self._build_lookup("cn", 'exact', "foo", field=CharField), AND)


### PR DESCRIPTION
Add minimal tests for django-ldapdb/django-ldapdb#130.

I'm still uncomfortable with the date format systematically set to be `%F` even when the field format is `%Y%m%d%H%M%SZ`.